### PR TITLE
Promise.isDispatched now exposed as read-only var

### DIFF
--- a/src/org/osflash/signals/Promise.as
+++ b/src/org/osflash/signals/Promise.as
@@ -1,20 +1,20 @@
 package org.osflash.signals
 {
     import flash.errors.IllegalOperationError;
-
+    
     import org.osflash.signals.ISlot;
     import org.osflash.signals.OnceSignal;
 
     public class Promise extends OnceSignal
     {
-        private var isDispatched:Boolean;
+        private var _isDispatched:Boolean;
         private var valueObjects:Array;
 
         /** @inheritDoc */
         override public function addOnce(listener:Function):ISlot
         {
             var slot:ISlot = super.addOnce(listener);
-            if (isDispatched)
+            if (_isDispatched)
             {
                 slot.execute(valueObjects);
                 slot.remove();
@@ -29,16 +29,21 @@ package org.osflash.signals
          */
         override public function dispatch(...valueObjects):void
         {
-            if (isDispatched)
+            if (_isDispatched)
             {
                 throw new IllegalOperationError("You cannot dispatch() a Promise more than once");
             }
             else
             {
-                isDispatched = true;
+                _isDispatched = true;
                 this.valueObjects = valueObjects;
                 super.dispatch.apply(this, valueObjects);
             }
         }
+		
+		public function get isDispatched():Boolean
+		{
+			return _isDispatched;
+		}
     }
 }


### PR DESCRIPTION
It's sometimes necessary, or at least useful to check whether a promise signal has already been dispatched.